### PR TITLE
Remove duration constructors feature

### DIFF
--- a/src/api/decoder.rs
+++ b/src/api/decoder.rs
@@ -8,6 +8,7 @@ use crate::pkl::{
     internal::{IPklValue, ObjectMember, PklNonPrimitive, PklPrimitive},
     PklMod,
 };
+use crate::utils;
 use crate::value::{
     datasize::{DataSize, DataSizeUnit},
     PklValue,
@@ -160,9 +161,33 @@ fn decode_non_prim_member(type_id: u64, slots: &[rmpv::Value]) -> Result<PklNonP
             let float_time = slots[0].as_f64().expect("expected float for duration") as u64;
             let duration_unit = slots[1].as_str().expect("expected time type");
             let duration = match duration_unit {
-                "min" => std::time::Duration::from_mins(float_time),
-                "h" => std::time::Duration::from_hours(float_time),
-                "d" => std::time::Duration::from_days(float_time),
+                "min" => {
+                    let Some(d) = utils::duration::from_mins(float_time) else {
+                        return Err(Error::ParseError(format!(
+                            "failed to parse duration from mins: {}",
+                            float_time
+                        )));
+                    };
+                    d
+                }
+                "h" => {
+                    let Some(d) = utils::duration::from_hours(float_time) else {
+                        return Err(Error::ParseError(format!(
+                            "failed to parse duration from hours: {}",
+                            float_time
+                        )));
+                    };
+                    d
+                }
+                "d" => {
+                    let Some(d) = utils::duration::from_days(float_time) else {
+                        return Err(Error::ParseError(format!(
+                            "failed to parse duration from days: {}",
+                            float_time
+                        )));
+                    };
+                    d
+                }
                 "ns" => std::time::Duration::from_nanos(float_time),
                 "us" => std::time::Duration::from_micros(float_time),
                 "ms" => std::time::Duration::from_millis(float_time),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(duration_constructors)]
-
 use pkl::Deserializer;
 use pkl::PklSerialize;
 

--- a/src/utils/duration.rs
+++ b/src/utils/duration.rs
@@ -1,0 +1,44 @@
+use std::time::Duration;
+
+#[cfg(feature = "trace")]
+use tracing::debug;
+
+use crate::utils::macros::_trace;
+
+// work around to avoid requiring unstable feature `duration_constructors` https://github.com/rust-lang/rust/issues/120301
+
+const SECS_PER_MINUTE: u64 = 60;
+const MINS_PER_HOUR: u64 = 60;
+const HOURS_PER_DAY: u64 = 24;
+
+#[inline]
+pub const fn from_days(days: u64) -> Option<Duration> {
+    if days > u64::MAX / (SECS_PER_MINUTE * MINS_PER_HOUR * HOURS_PER_DAY) {
+        _trace!("overflow in Duration::from_days");
+        return None;
+    }
+
+    Some(Duration::from_secs(
+        days * MINS_PER_HOUR * SECS_PER_MINUTE * HOURS_PER_DAY,
+    ))
+}
+
+#[inline]
+pub const fn from_hours(hours: u64) -> Option<Duration> {
+    if hours > u64::MAX / (SECS_PER_MINUTE * MINS_PER_HOUR) {
+        _trace!("overflow in Duration::from_hours");
+        return None;
+    }
+
+    Some(Duration::from_secs(hours * MINS_PER_HOUR * SECS_PER_MINUTE))
+}
+
+#[inline]
+pub const fn from_mins(mins: u64) -> Option<Duration> {
+    if mins > u64::MAX / SECS_PER_MINUTE {
+        _trace!("overflow in Duration::from_mins");
+        return None;
+    }
+
+    Some(Duration::from_secs(mins * SECS_PER_MINUTE))
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,38 @@
+pub(crate) mod duration;
+
+// helper macro to conditionally log trace messages
+mod macros {
+    macro_rules! _trace {
+        ($($arg:tt)*) => {
+            #[cfg(feature = "trace")]
+            tracing::trace!($($arg)*);
+        };
+    }
+
+    macro_rules! _debug {
+        ($($arg:tt)*) => {
+            #[cfg(feature = "trace")]
+            tracing::debug!($($arg)*);
+        };
+    }
+
+    macro_rules! _info {
+        ($($arg:tt)*) => {
+            #[cfg(feature = "trace")]
+            tracing::info!($($arg)*);
+        };
+    }
+
+    macro_rules! _warn {
+        ($($arg:tt)*) => {
+            #[cfg(feature = "trace")]
+            tracing::warn!($($arg)*);
+        };
+    }
+
+    pub(crate) use _trace;
+}
+
 pub fn canonicalize(path: impl AsRef<std::path::Path>) -> std::io::Result<std::path::PathBuf> {
     #[cfg(target_os = "windows")]
     {


### PR DESCRIPTION
- Removes `duration_constructors` feature to allow for use on `stable` ([#12](https://github.com/z-jxy/rpkl/issues/12))