### PR TITLE
Update EvaluatorOptions to be Clonable

### DIFF
--- a/src/api/evaluator.rs
+++ b/src/api/evaluator.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     io::{Read, Write},
     process::{Child, Command, Stdio},
+    sync::Arc,
 };
 
 #[cfg(feature = "indexmap")]
@@ -35,16 +36,16 @@ pub(crate) const CREATE_EVALUATOR_REQUEST_ID: u64 = 135;
 pub(crate) const OUTGOING_MESSAGE_REQUEST_ID: u64 = 9805131;
 
 // options that can be provided to the evaluator, such as properties (-p flag from CLI)
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct EvaluatorOptions {
     /// Properties to pass to the evaluator. Used to read from `props:` in `.pkl` files
     pub properties: Option<MapImpl<String, String>>,
 
     /// Client-side module readers
-    pub client_module_readers: Option<Vec<Box<dyn PklModuleReader>>>,
+    pub client_module_readers: Option<Vec<Arc<dyn PklModuleReader>>>,
 
     /// Client-side resource readers
-    pub client_resource_readers: Option<Vec<Box<dyn PklResourceReader>>>,
+    pub client_resource_readers: Option<Vec<Arc<dyn PklResourceReader>>>,
 
     /// External resource readers
     pub external_resource_readers: Option<HashMap<String, ExternalReader>>,
@@ -158,8 +159,8 @@ pub struct Evaluator {
     pub evaluator_id: i64,
     stdin: std::process::ChildStdin,
     stdout: std::process::ChildStdout,
-    client_module_readers: Vec<Box<dyn PklModuleReader>>,
-    client_resource_readers: Vec<Box<dyn PklResourceReader>>,
+    client_module_readers: Vec<Arc<dyn PklModuleReader>>,
+    client_resource_readers: Vec<Arc<dyn PklResourceReader>>,
 }
 
 impl Evaluator {

--- a/src/api/external_reader.rs
+++ b/src/api/external_reader.rs
@@ -1,6 +1,7 @@
-use std::io::Write;
+use std::{io::Write, sync::Arc};
 
 use crate::internal::msgapi::{
+    PklMessage,
     codes::{
         CLOSE_EXTERNAL_PROCESS, INITIALIZE_MODULE_READER_REQUEST,
         INITIALIZE_RESOURCE_READER_REQUEST, LIST_MODULES_REQUEST, LIST_RESOURCES_REQUEST,
@@ -11,7 +12,6 @@ use crate::internal::msgapi::{
         ClientModuleReader, ClientResourceReader, InitializeModuleReaderResponse,
         InitializeResourceReaderResponse,
     },
-    PklMessage,
 };
 
 use crate::{
@@ -26,8 +26,8 @@ use crate::{
 
 #[derive(Default)]
 pub struct ExternalReaderRuntime {
-    resource_readers: Vec<Box<dyn PklResourceReader>>,
-    module_readers: Vec<Box<dyn PklModuleReader>>,
+    resource_readers: Vec<Arc<dyn PklResourceReader>>,
+    module_readers: Vec<Arc<dyn PklModuleReader>>,
 }
 
 impl ExternalReaderRuntime {

--- a/src/internal/msgapi/outgoing.rs
+++ b/src/internal/msgapi/outgoing.rs
@@ -5,12 +5,12 @@ use crate::internal::msgapi::codes::*;
 use serde::Serialize;
 
 use crate::{
+    EvaluatorOptions,
     api::{
         evaluator::CREATE_EVALUATOR_REQUEST_ID,
         reader::{PklModuleReader, PklResourceReader},
     },
     internal::msgapi::impl_pkl_message,
-    EvaluatorOptions,
 };
 
 impl From<&dyn PklModuleReader> for ClientModuleReader {
@@ -327,7 +327,7 @@ impl PathElements {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct ExternalReader {
     /// May be specified as an absolute path to an executable
     /// May also be specified as just an executable name, in which case it will be resolved according to the PATH environment variable


### PR DESCRIPTION
Updated `EvaluatorOptions` and the Module/Resource reader api to use `Arc<dyn PklModuleReader>` and `Arc<dyn PklResourceReader>` where Box was used previously.

Resolves #30 