### PR TITLE
feat: add HTTP proxy and timeout support to EvaluatorOptions

### DIFF
--- a/examples/http_proxy.rs
+++ b/examples/http_proxy.rs
@@ -1,0 +1,68 @@
+//! Example demonstrating HTTP proxy configuration for pkl evaluation.
+//!
+//! This is useful when you need to fetch remote pkl packages through a corporate proxy.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example http_proxy
+//! ```
+
+use rpkl::{EvaluatorOptions, HttpOptions, HttpProxy};
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct Config {
+    ip: Option<String>,
+    port: u16,
+    database: Database,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct Database {
+    username: String,
+    password: String,
+}
+
+fn main() {
+    // Example 1: Simple proxy configuration
+    let _simple_proxy = EvaluatorOptions::new()
+        .http(HttpOptions::new().proxy(HttpProxy::new("http://proxy.example.com:8080")));
+
+    // Example 2: Proxy with no_proxy list for bypassing certain hosts
+    let _proxy_with_bypass = EvaluatorOptions::new().http(
+        HttpOptions::new().proxy(
+            HttpProxy::new("http://proxy.example.com:8080")
+                .no_proxy(["localhost", "127.0.0.1", "*.internal.company.com", "10.0.0.0/8"]),
+        ),
+    );
+
+    // Example 3: Full configuration with proxy, timeout, and properties
+    let options = EvaluatorOptions::new()
+        .http(
+            HttpOptions::new().proxy(
+                HttpProxy::new("http://proxy.example.com:8080")
+                    .no_proxy(["localhost", "127.0.0.1"]),
+            ),
+        )
+        .timeout_seconds(60)
+        .property("environment", "production");
+
+    println!("Configured evaluator options with HTTP proxy:");
+    println!("  - Proxy: {:?}", options.http.as_ref().and_then(|h| h.proxy.as_ref()).and_then(|p| p.address.as_ref()));
+    println!("  - No-proxy: {:?}", options.http.as_ref().and_then(|h| h.proxy.as_ref()).and_then(|p| p.no_proxy.as_ref()));
+    println!("  - Timeout: {:?} seconds", options.timeout_seconds);
+
+    // Actually evaluate a local pkl file (no proxy needed for local files)
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("pkl")
+        .join("database.pkl");
+
+    // Use default options for local file (proxy only needed for remote packages)
+    let config: Config = rpkl::from_config(&path).unwrap();
+    println!("\nLoaded config: {config:?}");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod value;
 
 pub use error::{Error, Result};
 
-pub use api::evaluator::EvaluatorOptions;
+pub use api::evaluator::{EvaluatorOptions, HttpOptions, HttpProxy};
 
 pub use value::PklValue as Value;
 


### PR DESCRIPTION
## Summary

Add support for configuring HTTP proxy settings and evaluation timeout when creating a pkl evaluator. This enables users behind corporate proxies to fetch remote pkl packages.

## Changes

**New types:**
- `HttpProxy`: Configure proxy address and no_proxy bypass list
- `HttpOptions`: Configure proxy and CA certificates for HTTPS

**New `EvaluatorOptions` methods:**
- `.http(HttpOptions)`: Set HTTP configuration
- `.timeout_seconds(u64)`: Set evaluation timeout

These options are passed to pkl via the CreateEvaluator message's `http` and `timeoutSeconds` fields (added in Pkl 0.26.0).

## Example usage

```rust
use rpkl::{EvaluatorOptions, HttpOptions, HttpProxy};

let options = EvaluatorOptions::new()
    .http(HttpOptions::new()
        .proxy(HttpProxy::new("http://proxy.example.com:8080")
            .no_proxy(["localhost", "127.0.0.1"])))
    .timeout_seconds(60);

let config: Config = rpkl::from_config_with_options("config.pkl", options)?;
```

## Test plan

- [x] Added unit tests for `HttpProxy`, `HttpOptions`, and `EvaluatorOptions` builder methods
- [x] Added example `http_proxy.rs` demonstrating proxy configuration
- [x] All existing tests pass
- [x] Compiles without errors

## References

- [Pkl Message Passing API - CreateEvaluator](https://pkl-lang.org/main/current/bindings-specification/message-passing-api.html#create-evaluator-request)
- [Pkl CLI --http-proxy flag](https://pkl-lang.org/main/current/pkl-cli/index.html#root-options)